### PR TITLE
Add scripts to conveniently analyze a single run; updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,16 @@ Change to the output directory and then analyze the second step:
 Use as input to the `cmsDriver.py` command:
 
     cmsDriver.py analyze \
-      --conditions auto:phase1_2017_realistic \
-      -s RAW2DIGI,DIGI --geometry DB:Extended --era Run2_2017 \
+      --conditions auto:phase1_2018_realistic \
+      -s RAW2DIGI,DIGI --geometry DB:Extended --era Run2_2018 \
       --customise Debug/HcalDebug/customize.analyze_raw_tp \
       --customise Debug/HcalDebug/customize.analyze_reemul_tp \
-      --filein das:/RelValTTbarLepton_13/CMSSW_9_0_0_pre6-90X_upgrade2017_realistic_v15-v1/GEN-SIM-DIGI-RAW \
+      --filein das:/RelValQCD_FlatPt_15_3000HS_13/CMSSW_10_1_0_pre3-101X_upgrade2018_realistic_v3-v1/GEN-SIM-DIGI-RAW \
       -n 1000
 
 ## From Data, Using L1T Digis
 
-Using a run with HF FG bit mis-matches between L1T inputs (HCAL RAW does
-not include FG bits) and re-emulation:
+Using a run with HF FG bit mis-matches between L1T inputs and re-emulation:
 
     cmsDriver.py analyze \
       --data --conditions auto:run2_data \
@@ -54,12 +53,12 @@ not include FG bits) and re-emulation:
 
 ## From Data, Using L1T Digis and comparing with RecHits
 
-As before, but using files to contain primary and secondary inputs, and
+As before, but using files that contain primary and secondary input file lists, and
 adding TriggerPrimitive to RecHit comparisons:
 
     cmsDriver.py analyze \
-      --data --conditions 92X_dataRun2_Prompt_v8 \
-      -s RAW2DIGI --geometry DB:Extended --era Run2_2017 \
+      --data --conditions 100X_dataRun2_HLT_v3 \
+      -s RAW2DIGI --geometry DB:Extended --era Run2_2018 \
       --no_output \
       --customise Debug/HcalDebug/customize.analyze_l1t_tp \
       --customise Debug/HcalDebug/customize.analyze_raw_tp \
@@ -68,6 +67,20 @@ adding TriggerPrimitive to RecHit comparisons:
       --customise Debug/HcalDebug/customize.compare_raw_reco_sev9 \
       --customise Debug/HcalDebug/customize.compare_raw_reco_sev9999 \
       --customise Debug/HcalDebug/customize.use_data_reemul_tp \
-      --filein=$(<~/JetHTRECO.txt) \
-      --secondfilein=$(<~/JetHT.txt) \
+      --filein=filelist:JetHTRECO.txt \
+      --secondfilein=filelist:JetHT.txt \
       -n 50000
+
+## Analyzing one run (global)
+
+The script `one_run.py` provides a quick way to generate a configuration for the analysis of a single run. To analyze run 312712 of the `HcalNZS` dataset in the `Commissioning2018` run period:
+
+    ./one_run.py -r 312712 -t HcalNZS -p Commissioning2018
+
+This will run a DAS command to find the appropriate files before generating the analysis configuration.
+
+## Analyzing one run (local)
+
+Local runs are based on `HcalTBSource` rather than `PoolSource` input and so cannot currently be analyzed with `cmsDriver.py` commands, but the `one_run.py` script can be used with the `-t local` option provides an alternative:
+
+    ./one_run.py -r 312717 -t local

--- a/plugins/CompareTP.cc
+++ b/plugins/CompareTP.cc
@@ -90,6 +90,8 @@ class CompareTP : public edm::EDAnalyzer {
 
       bool swap_iphi_;
 
+      int run_;
+      int lumi_;
       int event_;
 
       TTree *tps_;
@@ -122,6 +124,8 @@ CompareTP::CompareTP(const edm::ParameterSet& config) :
    consumes<HcalTrigPrimDigiCollection>(edigis_);
 
    tps_ = fs->make<TTree>("tps", "Trigger primitives");
+   tps_->Branch("run", &run_);
+   tps_->Branch("lumi", &lumi_);
    tps_->Branch("event", &event_);
    tps_->Branch("ieta", &tp_ieta_);
    tps_->Branch("iphi", &tp_iphi_);
@@ -159,6 +163,8 @@ CompareTP::analyze(const edm::Event& event, const edm::EventSetup& setup)
 {
    using namespace edm;
 
+   run_ = event.id().run();
+   lumi_ = event.id().luminosityBlock();
    event_ = event.id().event();
 
    Handle<HcalTrigPrimDigiCollection> digis;

--- a/test/analyze_2018_tp_data_LOCALBASE.py
+++ b/test/analyze_2018_tp_data_LOCALBASE.py
@@ -1,0 +1,71 @@
+"""
+Template for analyzing local runs. Can be configured
+with script one_run.py
+"""
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+from Configuration.StandardSequences.Eras import eras
+
+RUN = 'RUNNUMBER'
+GT = 'GLOBALTAG'
+
+process = cms.Process('PLOT', eras.Run2_2018)
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
+# syntax for override of a single condition
+#override = 'HcalElectronicsMap_2018_v3.0_data,HcalElectronicsMapRcd,frontier://FrontierProd/CMS_CONDITIONS'
+override = ''
+process.GlobalTag = GlobalTag(process.GlobalTag, GT, override)
+
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(-1))
+
+process.source = cms.Source(
+    "HcalTBSource",
+    fileNames=cms.untracked.vstring(
+        '/store/group/dpg_hcal/comm_hcal/USC/run' + RUN + '/USC_' + RUN + '.root'
+    )
+)
+
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
+process.load("SimCalorimetry.Configuration.hcalDigiSequence_cff")
+process.load('CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi')
+process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
+
+process.TFileService = cms.Service("TFileService",
+                                   closeFileFast=cms.untracked.bool(True),
+                                   fileName=cms.string('analyze_' + RUN + '.root'))
+
+# LUTGenerationMode = False => use L1TriggerObjects (for data)
+# LUTGenerationMode = True => use L1TriggerObjects (for MC; default)
+process.HcalTPGCoderULUT.LUTGenerationMode = cms.bool(False)
+process.simHcalTriggerPrimitiveDigis.inputLabel = cms.VInputTag("hcalDigis", "hcalDigis")
+process.simHcalTriggerPrimitiveDigis.inputUpgradeLabel = cms.VInputTag("hcalDigis", "hcalDigis")
+# linear LUTs are used by default
+#process.CaloTPGTranscoder.linearLUTs = cms.bool(False)
+#process.HcalTPGCoderULUT.linearLUTs = cms.bool(False)
+
+process.hcalDigis.silent = cms.untracked.bool(False)
+process.hcalDigis.InputLabel = cms.InputTag("source")
+# default is True
+#process.hcalDigis.FilterDataQuality = cms.bool(False)
+#process.hcalDigis.FEDs = [1100, 1101, 1102, 1103, 1104, 1105, 1106, 1107, 1108, 1109, 1110, 1111, 1112, 1113, 1114, 1115, 1116, 1117]
+
+
+process.analyzeRAW = cms.EDAnalyzer("AnalyzeTP",
+                                    triggerPrimitives=cms.InputTag("hcalDigis", "", ""))
+process.analyzeSIM = cms.EDAnalyzer("AnalyzeTP",
+                                    triggerPrimitives=cms.InputTag("simHcalTriggerPrimitiveDigis", "", ""))
+process.compare = cms.EDAnalyzer("CompareTP",
+                                 triggerPrimitives=cms.InputTag("hcalDigis"),
+                                 emulTriggerPrimitives=cms.InputTag("simHcalTriggerPrimitiveDigis"),
+                                 swapIphi=cms.bool(False),
+                                 swapIeta=cms.bool(False))
+
+process.p = cms.Path(
+    process.hcalDigis *
+    process.simHcalTriggerPrimitiveDigis *
+    process.analyzeRAW *
+    process.analyzeSIM *
+    process.compare)

--- a/test/one_run.py
+++ b/test/one_run.py
@@ -4,6 +4,16 @@ Create configuration file to make data/emulation comparisons for one run.
 """
 import os, argparse, shutil
 
+def check_setup():
+    """Check that valid proxy is available; needed to
+    access DAS."""
+    exit_code = os.system('voms-proxy-info -exists')
+    if(exit_code != 0):
+        print "Obtain valid proxy with 'voms-proxy-init -voms cms -rfc'"
+        return False
+    else:
+        return True
+
 def main():
     """Generate configuration file given primary dataset,
     conditions, run period, and era."""
@@ -27,7 +37,7 @@ def main():
     if(args.type):
         primary_dataset = args.type
         
-    if(primary_dataset != "local"):
+    if(primary_dataset != "local" and check_setup()):
         filename = 'filelist_' + runnumber + '_' + primary_dataset + '.txt'
         output_filename = "\\\'analyze_" + runnumber + ".root\\\'"
 

--- a/test/one_run.py
+++ b/test/one_run.py
@@ -1,0 +1,63 @@
+#!/bin/env python
+"""
+Create configuration file to make data/emulation comparisons for one run.
+"""
+import os, argparse, shutil
+
+def main():
+    """Generate configuration file given primary dataset,
+    conditions, run period, and era."""
+    primary_dataset = 'HcalNZS'
+    conditions = '100X_dataRun2_HLT_v1'
+    period = 'Commissioning2018'
+    era = 'Run2_2018'
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-r', "--run", required = True)
+    parser.add_argument('-g', "--globaltag")
+    parser.add_argument('-p', "--runperiod")
+    parser.add_argument('-e', "--era")
+    parser.add_argument('-t', "--type")
+    args = parser.parse_args()
+    runnumber = args.run
+    if(args.globaltag):
+        conditions = args.globaltag
+    if(args.runperiod):
+        period = args.runperiod
+    if(args.type):
+        primary_dataset = args.type
+        
+    if(primary_dataset != "local"):
+        filename = 'filelist_' + runnumber + '_' + primary_dataset + '.txt'
+        output_filename = "\\\'analyze_" + runnumber + ".root\\\'"
+
+        # get filelist from DAS
+        das_command = 'dasgoclient --query="file dataset=/' \
+            + primary_dataset + '/' + period + '-v1/RAW run=' \
+            + runnumber + '" > ' + filename
+        print "Getting filelist using DAS query:\n" + das_command
+        os.system(das_command)
+
+        # generate cmsDriver.py command
+        cmsdriver_command = "cmsDriver.py" \
+            + " analyze --data --conditions " + conditions \
+            + " -s RAW2DIGI --geometry DB:Extended --era " + era \
+            + " --customise Debug/HcalDebug/customize.compare_raw_reemul_tp" \
+            + " --customise Debug/HcalDebug/customize.use_data_reemul_tp" \
+            + " --customise_commands" \
+            + " process.TFileService.fileName=cms.string\(" + output_filename + "\)" \
+            + " --filein=filelist:" + filename \
+            + " --python_filename=analyze_" + runnumber + ".py" \
+            + " --no_exec -n -1 --no_output " 
+        print "Using cmsDriver.py command:\n" + cmsdriver_command
+        os.system(cmsdriver_command)
+
+    # HcalTBSource cannot currently be specified in a cmsDriver.py command
+    # so a special treatment is necessary
+    else:
+        newfile = 'analyze_2018_tp_data_' + runnumber + '.py'
+        shutil.copy2('analyze_2018_tp_data_LOCALBASE.py', newfile)
+        os.system("sed -i 's/RUNNUMBER/" + runnumber + "/' " + newfile)
+        os.system("sed -i 's/GLOBALTAG/" + conditions + "/' " + newfile)
+                     
+main()

--- a/test/one_run.py
+++ b/test/one_run.py
@@ -8,7 +8,7 @@ def main():
     """Generate configuration file given primary dataset,
     conditions, run period, and era."""
     primary_dataset = 'HcalNZS'
-    conditions = '100X_dataRun2_HLT_v1'
+    conditions = '100X_dataRun2_HLT_v3'
     period = 'Commissioning2018'
     era = 'Run2_2018'
 


### PR DESCRIPTION
This PR adds a script to conveniently generate a configuration for making data vs emulation comparisons for a single run. It either:

- queries DAS for the appropriate files (global)
or
- uses a template configuration for local runs

The `HcalNZS` dataset is used by default for global runs, and a sensible default global tag is provided for both global and local runs.

The README file has been updated to reflect these changes.